### PR TITLE
added total balance

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>573</width>
+    <width>637</width>
     <height>455</height>
    </rect>
   </property>
@@ -24,7 +24,7 @@
        <property name="styleSheet">
         <string notr="true">#frame { background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1, stop:0 rgba(70,71,71,15), stop:1.0 rgba(70,71,71,0)); }</string>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_4">   
+       <layout class="QVBoxLayout" name="verticalLayout_4">
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_4">
           <item>
@@ -246,7 +246,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
+          <item row="6" column="0">
            <widget class="QLabel" name="labelUpdateStatic">
             <property name="font">
              <font>
@@ -263,7 +263,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="6" column="1">
            <widget class="QLabel" name="labelUpdateStatus">
             <property name="toolTip">
              <string>A new client version has been released!</string>
@@ -276,6 +276,32 @@
             </property>
             <property name="alignment">
              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="labelTotalText">
+            <property name="text">
+             <string>Total balance:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QLabel" name="labelTotal">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="toolTip">
+             <string>Total includes: balance, stake and unconfirmed values</string>
+            </property>
+            <property name="text">
+             <string>0 XMG</string>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
             </property>
            </widget>
           </item>
@@ -303,7 +329,7 @@
         <string/>
        </property>
        <property name="pixmap">
-        <pixmap resource="../bitcoin.qrc">:/images/backg</pixmap>
+        <pixmap>:/images/backg</pixmap>
        </property>
        <property name="scaledContents">
         <bool>false</bool>
@@ -408,8 +434,6 @@
    </item>
   </layout>
  </widget>
- <resources>
-  <include location="../bitcoin.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -170,6 +170,7 @@ void OverviewPage::setBalance(qint64 balance, qint64 stake, qint64 unconfirmedBa
     ui->labelStake->setText(BitcoinUnits::formatWithUnit(unit, stake));
     ui->labelUnconfirmed->setText(BitcoinUnits::formatWithUnit(unit, unconfirmedBalance));
     ui->labelImmature->setText(BitcoinUnits::formatWithUnit(unit, immatureBalance));
+    ui->labelTotal->setText(BitcoinUnits::formatWithUnit(unit, (balance + stake + unconfirmedBalance)));
 
     // only show immature (newly mined) balance if it's non-zero, so as not to complicate things
     // for the non-mining users


### PR DESCRIPTION
There are two "label_6" labels on the overviewpage.ui form, I think the second should be deleted it causes a warning.  The color value under the styleSheet for the other labels should be deleted too the default value looks better and improves contrast on the tool tips imo.  When merging this should be made consistent through the labels for best visual appearance the new "Total balance" has no style sheet color value added.
