### PR TITLE
Enhancing version checking, addressing error

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -277,6 +277,10 @@ void OverviewPage::checkForUpdates()
     {
         report = QString("Malformed wallet version retrieved");
     }
+
+    // Here, we need to check version very thoroughly, otherwise the version numbers of
+    // higher significance (Major, Minor, Revision) can be ignored if the lower
+    // significance numbers are higher
     else
     {
         value = atoi(v_siteString.at(0).c_str());
@@ -289,21 +293,57 @@ void OverviewPage::checkForUpdates()
             value = atoi(v_siteString.at(1).c_str());
             if (value > DISPLAY_VERSION_MINOR)
             {
-                isUpToDate = false;
+                // Check to make sure major version is also greater than or equal to
+                // the current version
+                value = atoi(v_siteString.at(0).c_str());
+                if (value >= DISPLAY_VERSION_MAJOR)
+                {
+                    isUpToDate = false;
+                }
             }
             else
             {
                 value = atoi(v_siteString.at(2).c_str());
                 if (value > DISPLAY_VERSION_REVISION)
                 {
-                    isUpToDate = false;
+                    // Check to make sure minor version is also greater than or equal
+                    // to the current version
+                    value = atoi(v_siteString.at(1).c_str());
+                    if (value >= DISPLAY_VERSION_MINOR)
+                    {
+                        // Check to make sure major version is also greater than or
+                        // equal to the current version
+                        value = atoi(v_siteString.at(0).c_str());
+                        if (value >= DISPLAY_VERSION_MAJOR)
+                        {
+                            isUpToDate = false;
+                        }
+                    }
                 }
                 else
                 {
                     value = atoi(v_siteString.at(3).c_str());
                     if (value > DISPLAY_VERSION_BUILD)
                     {
-                        isUpToDate = false;
+                        // Check to make sure revision number is also greater than or
+                        // equal to the current revision
+                        value = atoi(v_siteString.at(2).c_str());
+                        if (value >= DISPLAY_VERSION_REVISION)
+                         {
+                            // Check to make sure minor version is also greater than or
+                            // equal to the current version
+                            value = atoi(v_siteString.at(1).c_str());
+                            if (value >= DISPLAY_VERSION_MINOR)
+                            {
+                                // Check to make sure major version is also greater than
+                                // or equal to the current version
+                                value = atoi(v_siteString.at(0).c_str());
+                                if (value >= DISPLAY_VERSION_MAJOR)
+                                {
+                                    isUpToDate = false;
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/src/qt/updatecheck.cpp
+++ b/src/qt/updatecheck.cpp
@@ -3,7 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "updatecheck.h"
- 
+//#include <iostream>
+
 UpdateCheck::UpdateCheck(QUrl updateUrl, QObject *parent) :
  QObject(parent)
 {
@@ -32,6 +33,11 @@ std::vector<std::string> UpdateCheck::splitString(std::string input, std::string
     std::vector<std::string> output;
     size_t start = 0;
     size_t end = 0;
+
+    //DEBUG: In order to ensure we aren't having errors receiving the version info,
+    //       print the string that we read in the console.
+    //       This should *not* be enabled in the released wallet
+    //std::cout << "Version String Received: " << input << std::endl;
 
     // Until we hit the end of the string, push string chunks
     // into the return array


### PR DESCRIPTION
Version checking robustness has been improved by adding several more comparisons. This
fixes a possible error that should theoretically never show up in practice: if the
client version number (1.2.3.0, for example) had any digits lower than the externally
hosted version.txt file (0.4.3.1, for example), the client would issue an update alert.
This commit adds nested comparisons with each more significant version number
to alleviate this issue and conform to expected behavior.

Additionally, it has come to my attention that the Magi version file hosted at
http://coinmagi.org/files/magi-release/version.txt is inaccessible to the client due to
the site's mod_security filtering rules. Instead of receiving a version string, the
client receives the following:

```
<html>
<head><title>Not Acceptable!</title></head>
<body>
<h1>Not Acceptable!</h1>
<p>An appropriate representation of the requested
resource could not be found on this server.
This error was generated by Mod_Security.</p>
</body>
</html>
```

Unfortunately, this error will persist unless the htaccess file on the server is
modified or until a more permissive host is used for the version file.
