### PR TITLE
Added a total to transaction view

### DIFF
--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -29,7 +29,8 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     QDateTime datetime = index.data(TransactionTableModel::DateRole).toDateTime();
     QString address = index.data(TransactionTableModel::AddressRole).toString();
     QString label = index.data(TransactionTableModel::LabelRole).toString();
-    qint64 amount = llabs(index.data(TransactionTableModel::AmountRole).toLongLong());
+    qint64 amount = index.data(TransactionTableModel::AmountRole).toLongLong();
+    qint64 abs_amount = llabs(amount);
 
     if(!(TYPE(type) & typeFilter))
         return false;
@@ -37,8 +38,10 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
         return false;
     if (!address.contains(addrPrefix, Qt::CaseInsensitive) && !label.contains(addrPrefix, Qt::CaseInsensitive))
         return false;
-    if(amount < minAmount)
+    if(abs_amount < minAmount)
         return false;
+
+    totalAmount += amount;
 
     return true;
 }
@@ -47,24 +50,28 @@ void TransactionFilterProxy::setDateRange(const QDateTime &from, const QDateTime
 {
     this->dateFrom = from;
     this->dateTo = to;
+    totalAmount = 0;
     invalidateFilter();
 }
 
 void TransactionFilterProxy::setAddressPrefix(const QString &addrPrefix)
 {
     this->addrPrefix = addrPrefix;
+    totalAmount = 0;
     invalidateFilter();
 }
 
 void TransactionFilterProxy::setTypeFilter(quint32 modes)
 {
     this->typeFilter = modes;
+    totalAmount = 0;
     invalidateFilter();
 }
 
 void TransactionFilterProxy::setMinAmount(qint64 minimum)
 {
     this->minAmount = minimum;
+    totalAmount = 0;
     invalidateFilter();
 }
 

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -3,6 +3,7 @@
 
 #include <QSortFilterProxyModel>
 #include <QDateTime>
+#include <inttypes.h>
 
 /** Filter the transaction list according to pre-specified rules. */
 class TransactionFilterProxy : public QSortFilterProxyModel
@@ -32,6 +33,9 @@ public:
     void setLimit(int limit);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
+
+    int64_t getTotalAmount() const { return totalAmount; }
+
 protected:
     bool filterAcceptsRow(int source_row, const QModelIndex & source_parent) const;
 
@@ -42,6 +46,7 @@ private:
     quint32 typeFilter;
     qint64 minAmount;
     int limitRows;
+    mutable int64_t totalAmount;
 
 signals:
 

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -187,6 +187,9 @@ void TransactionView::setModel(WalletModel *model)
 #endif
         transactionView->horizontalHeader()->resizeSection(
                 TransactionTableModel::Amount, 100);
+
+        transactionProxyModel->setMinAmount(0);
+        updateTotalAmount();
     }
 }
 
@@ -195,7 +198,7 @@ void TransactionView::chooseDate(int idx)
     if(!transactionProxyModel)
         return;
     QDate current = QDate::currentDate();
-    dateRangeWidget->setVisible(false);
+    enableDateRangeWidget(false);
     switch(dateWidget->itemData(idx).toInt())
     {
     case All:
@@ -232,10 +235,12 @@ void TransactionView::chooseDate(int idx)
                 TransactionFilterProxy::MAX_DATE);
         break;
     case Range:
-        dateRangeWidget->setVisible(true);
+        enableDateRangeWidget(true);
         dateRangeChanged();
         break;
     }
+
+    updateTotalAmount();
 }
 
 void TransactionView::chooseType(int idx)
@@ -244,6 +249,7 @@ void TransactionView::chooseType(int idx)
         return;
     transactionProxyModel->setTypeFilter(
         typeWidget->itemData(idx).toInt());
+    updateTotalAmount();
 }
 
 void TransactionView::changedPrefix(const QString &prefix)
@@ -251,6 +257,7 @@ void TransactionView::changedPrefix(const QString &prefix)
     if(!transactionProxyModel)
         return;
     transactionProxyModel->setAddressPrefix(prefix);
+    updateTotalAmount();
 }
 
 void TransactionView::changedAmount(const QString &amount)
@@ -266,6 +273,13 @@ void TransactionView::changedAmount(const QString &amount)
     {
         transactionProxyModel->setMinAmount(0);
     }
+    updateTotalAmount();
+}
+
+void TransactionView::updateTotalAmount()
+{
+    QString str = BitcoinUnits::format(BitcoinUnits::BTC, transactionProxyModel->getTotalAmount());
+    totalAmountWidget->setText(str);
 }
 
 void TransactionView::exportClicked()
@@ -379,6 +393,14 @@ void TransactionView::showDetails()
     }
 }
 
+void TransactionView::enableDateRangeWidget(bool enable)
+{
+    dateFrom->setVisible(enable);
+    dateTo->setVisible(enable);
+    to->setVisible(enable);
+    range->setVisible(enable);
+}
+
 QWidget *TransactionView::createDateRangeWidget()
 {
     dateRangeWidget = new QFrame();
@@ -387,7 +409,8 @@ QWidget *TransactionView::createDateRangeWidget()
     QHBoxLayout *layout = new QHBoxLayout(dateRangeWidget);
     layout->setContentsMargins(0,0,0,0);
     layout->addSpacing(23);
-    layout->addWidget(new QLabel(tr("Range:")));
+    range = new QLabel(tr("Range:"));
+    layout->addWidget(range);
 
     dateFrom = new QDateTimeEdit(this);
     dateFrom->setDisplayFormat("dd/MM/yy");
@@ -395,7 +418,8 @@ QWidget *TransactionView::createDateRangeWidget()
     dateFrom->setMinimumWidth(100);
     dateFrom->setDate(QDate::currentDate().addDays(-7));
     layout->addWidget(dateFrom);
-    layout->addWidget(new QLabel(tr("to")));
+    to = new QLabel(tr("to"));
+    layout->addWidget(to);
 
     dateTo = new QDateTimeEdit(this);
     dateTo->setDisplayFormat("dd/MM/yy");
@@ -405,8 +429,14 @@ QWidget *TransactionView::createDateRangeWidget()
     layout->addWidget(dateTo);
     layout->addStretch();
 
+    layout->addWidget(new QLabel(tr("Total:")));
+    totalAmountWidget = new QLabel(this);
+    totalAmountWidget->setText("0");
+    totalAmountWidget->setFixedWidth(120);
+    layout->addWidget(totalAmountWidget);
+
     // Hide by default
-    dateRangeWidget->setVisible(false);
+    enableDateRangeWidget(false);
 
     // Notify on change
     connect(dateFrom, SIGNAL(dateChanged(QDate)), this, SLOT(dateRangeChanged()));
@@ -422,6 +452,7 @@ void TransactionView::dateRangeChanged()
     transactionProxyModel->setDateRange(
             QDateTime(dateFrom->date()),
             QDateTime(dateTo->date()).addDays(1));
+    updateTotalAmount();
 }
 
 void TransactionView::focusTransaction(const QModelIndex &idx)

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -14,6 +14,7 @@ class QModelIndex;
 class QMenu;
 class QFrame;
 class QDateTimeEdit;
+class QLabel;
 QT_END_NAMESPACE
 
 /** Widget showing the transaction list for a wallet, including a filter row.
@@ -48,14 +49,22 @@ private:
     QComboBox *typeWidget;
     QLineEdit *addressWidget;
     QLineEdit *amountWidget;
+    QLabel *totalAmountWidgetLabel;
+    QLabel *totalAmountWidget;
 
     QMenu *contextMenu;
 
     QFrame *dateRangeWidget;
     QDateTimeEdit *dateFrom;
     QDateTimeEdit *dateTo;
+    QLabel *to;
+    QLabel *range;
 
     QWidget *createDateRangeWidget();
+
+private:
+    void updateTotalAmount();
+    void enableDateRangeWidget(bool enable);
 
 private slots:
     void contextualMenu(const QPoint &);


### PR DESCRIPTION
Code integrated from the hyperstake wallet by presstab with the addition of making the date input fields invisible unless a date range is being used.  Orphan stake values are added into the total.  If the repairwallet command removes orphans this issue of incorrect total would be fixed.
